### PR TITLE
Fix queue ordering bug

### DIFF
--- a/backend/routes/patents-api.js
+++ b/backend/routes/patents-api.js
@@ -31,6 +31,20 @@ async function getPatentQueue(req)
     // so, safe to only check queue[0]
     if(queue[0].items.length > 0)
     {
+      // retrieves information about patents in the order they are in the patents collection:
+      const patents = await Patent.find({
+        documentId: queue[0].items
+      });
+
+      console.log(patents)
+
+      // expensive to re-map the elements, but will gaurantee the queue order:
+      const orderedPatents = patents.map((item, index) => { 
+        return patents.find((i) => i.documentId == queue[0].items[index]); 
+      });
+
+      console.log(patents)
+      
       return await Patent.find({
         documentId: queue[0].items
       });

--- a/backend/routes/patents-api.js
+++ b/backend/routes/patents-api.js
@@ -36,17 +36,9 @@ async function getPatentQueue(req)
         documentId: queue[0].items
       });
 
-      console.log(patents)
-
-      // expensive to re-map the elements, but will gaurantee the queue order:
-      const orderedPatents = patents.map((item, index) => { 
+      // this will gaurantee the queue order:      
+      return patents.map((item, index) => { 
         return patents.find((i) => i.documentId == queue[0].items[index]); 
-      });
-
-      console.log(patents)
-      
-      return await Patent.find({
-        documentId: queue[0].items
       });
     }
     else // let's add some new patents:


### PR DESCRIPTION
When retrieving the queue:

the database was returning information about each patent in the order that it was in the "patents" collection,
and not in the order specified in the queue.

this re-maps the order before sending it back to the user.